### PR TITLE
fix bug in which compression is impossible when last SNP is too close to...

### DIFF
--- a/src/sequences.cpp
+++ b/src/sequences.cpp
@@ -409,7 +409,7 @@ bool find_compress_cols(const Sites *sites, int compress,
                    sites_mapping->all_sites[n-2]);
 
         // Check whether compression is not possible
-        if (next_block - compress > sites->end_coord)
+        if (next_block - compress > sites->end_coord && i != (ncols-1))
             return false;
     }
 


### PR DESCRIPTION
... end

Before this fix, compression always fails when the last SNP is near the end of the region.
